### PR TITLE
Integrate more nicely with SDL applications, support more Dear ImGui features

### DIFF
--- a/backends/imgui_impl_sdlrenderer.cpp
+++ b/backends/imgui_impl_sdlrenderer.cpp
@@ -66,8 +66,8 @@ static void ImGui_ImplSDLRenderer_SetupRenderState()
 	ImGui_ImplSDLRenderer_Data *bd = ImGui_ImplSDLRenderer_GetBackendData();
 
 	// Clear out any viewports and cliprects set by the user
-	SDL_RenderSetViewport(bd->renderer, NULL);
-	SDL_RenderSetClipRect(bd->renderer, NULL);
+	SDL_RenderSetViewport(bd->SDLRenderer, NULL);
+	SDL_RenderSetClipRect(bd->SDLRenderer, NULL);
 }
 
 void ImGui_ImplSDLRenderer_NewFrame()
@@ -148,7 +148,7 @@ void ImGui_ImplSDLRenderer_RenderDrawData(ImDrawData* draw_data)
                     int col_stride = sizeof(ImDrawVert);
                     int *color = (int*)((char*)vtx_buffer + IM_OFFSETOF(ImDrawVert, col));
 
-		    SDL_Texture *tex = (SDL_Texture*)pcmd->TextureID;
+		    SDL_Texture *tex = (SDL_Texture*)pcmd->TextureId;
 
                     SDL_RenderGeometryRaw(bd->SDLRenderer, tex, 
                             xy, xy_stride, color,

--- a/backends/imgui_impl_sdlrenderer.cpp
+++ b/backends/imgui_impl_sdlrenderer.cpp
@@ -42,25 +42,18 @@ static ImGui_ImplSDLRenderer_Data* ImGui_ImplSDLRenderer_GetBackendData()
 }
 
 // Functions
-bool ImGui_ImplSDLRenderer_Init(SDL_Window *window)
+bool ImGui_ImplSDLRenderer_Init(SDL_Renderer *renderer)
 {
     ImGuiIO& io = ImGui::GetIO();
     IM_ASSERT(io.BackendRendererUserData == NULL && "Already initialized a renderer backend!");
+    IM_ASSERT(renderer != NULL && "SDL_Renderer not initialized!");
 
     // Setup backend capabilities flags
     ImGui_ImplSDLRenderer_Data* bd = IM_NEW(ImGui_ImplSDLRenderer_Data)();
     io.BackendRendererUserData = (void*)bd;
     io.BackendRendererName = "imgui_impl_SDLRenderer";
 
-    bd->SDLRenderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_PRESENTVSYNC | SDL_RENDERER_ACCELERATED);
-    if (bd->SDLRenderer == NULL) {
-        SDL_Log("Error creating SDL renderer");
-        return false;
-    } else {
-        SDL_RendererInfo info;
-        SDL_GetRendererInfo(bd->SDLRenderer, &info);
-        SDL_Log("Current SDL Renderer: %s", info.name);
-    }
+    bd->SDLRenderer = renderer;
     return true;
 }
 
@@ -70,17 +63,10 @@ void ImGui_ImplSDLRenderer_Shutdown()
     ImGui_ImplSDLRenderer_Data* bd = ImGui_ImplSDLRenderer_GetBackendData();
 
     ImGui_ImplSDLRenderer_DestroyDeviceObjects();
-    SDL_DestroyRenderer(bd->SDLRenderer);
 
     io.BackendRendererName = NULL;
     io.BackendRendererUserData = NULL;
     IM_DELETE(bd);
-
-    if (SDL_GetError()) {
-        SDL_Log("Ending with SDL error: %s", SDL_GetError());
-    } else {
-        SDL_Log("Ending with no SDL error");
-    }
 }
 
 void ImGui_ImplSDLRenderer_NewFrame()
@@ -110,10 +96,6 @@ void ImGui_ImplSDLRenderer_RenderDrawData(ImDrawData* draw_data)
 
     ImGuiIO& io = ImGui::GetIO();
     ImGui_ImplSDLRenderer_Data* bd = ImGui_ImplSDLRenderer_GetBackendData();
-
-    ImVec4 clear_color = ImVec4(0.45f, 0.55f, 0.60f, 1.00f);
-    SDL_SetRenderDrawColor(bd->SDLRenderer, clear_color.x * 255, clear_color.y * 255, clear_color.z * 255 , clear_color.w * 255);
-    SDL_RenderClear(bd->SDLRenderer);
 
     for (int n = 0; n < draw_data->CmdListsCount; n++) {
 
@@ -178,8 +160,6 @@ void ImGui_ImplSDLRenderer_RenderDrawData(ImDrawData* draw_data)
             idx_buffer += pcmd->ElemCount;
         }
     }
-
-    SDL_RenderPresent(bd->SDLRenderer);
 }
 
 // Called by Init/NewFrame/Shutdown

--- a/backends/imgui_impl_sdlrenderer.cpp
+++ b/backends/imgui_impl_sdlrenderer.cpp
@@ -19,14 +19,6 @@
 #include <stdint.h>     // intptr_t
 #endif
 
-// Include OpenGL header (without an OpenGL loader) requires a bit of fiddling
-#if defined(_WIN32) && !defined(APIENTRY)
-#  define APIENTRY __stdcall                  // It is customary to use APIENTRY for OpenGL function pointer declarations on all platforms.  Additionally, the Windows OpenGL header needs APIENTRY.
-#endif
-#if defined(_WIN32) && !defined(WINGDIAPI)
-#  define WINGDIAPI __declspec(dllimport)     // Some Windows OpenGL headers need this
-#endif
-
 struct ImGui_ImplSDLRenderer_Data
 {
     SDL_Renderer *SDLRenderer;

--- a/backends/imgui_impl_sdlrenderer.cpp
+++ b/backends/imgui_impl_sdlrenderer.cpp
@@ -156,7 +156,7 @@ void ImGui_ImplSDLRenderer_RenderDrawData(ImDrawData* draw_data)
                     int col_stride = sizeof(ImDrawVert);
                     int *color = (int*)((char*)vtx_buffer + IM_OFFSETOF(ImDrawVert, col));
 
-		    SDL_Texture *tex = (SDL_Texture*)pcmd->TextureId;
+					SDL_Texture *tex = (SDL_Texture*)pcmd->TextureId;
 
                     SDL_RenderGeometryRaw(bd->SDLRenderer, tex, 
                             xy, xy_stride, color,

--- a/backends/imgui_impl_sdlrenderer.cpp
+++ b/backends/imgui_impl_sdlrenderer.cpp
@@ -148,7 +148,7 @@ void ImGui_ImplSDLRenderer_RenderDrawData(ImDrawData* draw_data)
                     int col_stride = sizeof(ImDrawVert);
                     int *color = (int*)((char*)vtx_buffer + IM_OFFSETOF(ImDrawVert, col));
 
-                    SDL_Texture *tex = (pcmd->TextureId == io.Fonts->TexID ? bd->FontTexture : NULL);
+		    SDL_Texture *tex = (SDL_Texture*)pcmd->TextureID;
 
                     SDL_RenderGeometryRaw(bd->SDLRenderer, tex, 
                             xy, xy_stride, color,

--- a/backends/imgui_impl_sdlrenderer.cpp
+++ b/backends/imgui_impl_sdlrenderer.cpp
@@ -173,7 +173,7 @@ bool ImGui_ImplSDLRenderer_CreateFontsTexture()
     unsigned char* pixels;
     int width, height;
     io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);   // Load as RGBA 32-bit (75% of the memory is wasted, but default font is so small) because it is more likely to be compatible with user's existing shaders. If your ImTextureId represent a higher-level concept than just a GL texture id, consider calling GetTexDataAsAlpha8() instead to save on GPU memory.
-    bd->FontTexture = SDL_CreateTexture(bd->SDLRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STATIC, width, height);
+    bd->FontTexture = SDL_CreateTexture(bd->SDLRenderer, SDL_PIXELFORMAT_RGBA32, SDL_TEXTUREACCESS_STATIC, width, height);
     if (bd->FontTexture == NULL) {
         SDL_Log("error creating texture");
         return false;

--- a/backends/imgui_impl_sdlrenderer.cpp
+++ b/backends/imgui_impl_sdlrenderer.cpp
@@ -61,6 +61,15 @@ void ImGui_ImplSDLRenderer_Shutdown()
     IM_DELETE(bd);
 }
 
+static void ImGui_ImplSDLRenderer_SetupRenderState()
+{
+	ImGui_ImplSDLRenderer_Data *bd = ImGui_ImplSDLRenderer_GetBackendData();
+
+	// Clear out any viewports and cliprects set by the user
+	SDL_RenderSetViewport(bd->renderer, NULL);
+	SDL_RenderSetClipRect(bd->renderer, NULL);
+}
+
 void ImGui_ImplSDLRenderer_NewFrame()
 {
     ImGui_ImplSDLRenderer_Data* bd = ImGui_ImplSDLRenderer_GetBackendData();
@@ -89,6 +98,8 @@ void ImGui_ImplSDLRenderer_RenderDrawData(ImDrawData* draw_data)
     ImGuiIO& io = ImGui::GetIO();
     ImGui_ImplSDLRenderer_Data* bd = ImGui_ImplSDLRenderer_GetBackendData();
 
+    ImGui_ImplSDLRenderer_SetupRenderState();
+
     for (int n = 0; n < draw_data->CmdListsCount; n++) {
 
         const ImDrawList* cmd_list = draw_data->CmdLists[n];
@@ -103,8 +114,7 @@ void ImGui_ImplSDLRenderer_RenderDrawData(ImDrawData* draw_data)
                 // User callback, registered via ImDrawList::AddCallback()
                 // (ImDrawCallback_ResetRenderState is a special callback value used by the user to request the renderer to reset render state.)
                 if (pcmd->UserCallback == ImDrawCallback_ResetRenderState) {
-                    SDL_Log("Aie SetupRenderState ?");
-                    // ImGui_ImplSDLRenderer_SetupRenderState(draw_data, fb_width, fb_height);
+                    ImGui_ImplSDLRenderer_SetupRenderState();
                 } else { 
                     pcmd->UserCallback(cmd_list, pcmd);
                 }

--- a/backends/imgui_impl_sdlrenderer.h
+++ b/backends/imgui_impl_sdlrenderer.h
@@ -7,7 +7,7 @@
 
 #include "SDL.h"
 
-IMGUI_IMPL_API bool     ImGui_ImplSDLRenderer_Init(SDL_Window *window);
+IMGUI_IMPL_API bool     ImGui_ImplSDLRenderer_Init(SDL_Renderer *renderer);
 IMGUI_IMPL_API void     ImGui_ImplSDLRenderer_Shutdown();
 IMGUI_IMPL_API void     ImGui_ImplSDLRenderer_NewFrame();
 IMGUI_IMPL_API void     ImGui_ImplSDLRenderer_RenderDrawData(ImDrawData* draw_data);


### PR DESCRIPTION
This pull request:

- Lets the user supply their own SDL_Renderer so they can configure it however they want (vsync, no vsync, TARGETTEXTURE, specific driver, etc.), and doesn't clear the renderer or call ```SDL_RenderPresent()```.

- Provides a ```SetupRenderState()``` function so that any cliprects or viewports already set don't interfere with Dear ImGui. This also lets us perform the ```ImDrawCallback_ResetRenderState``` draw command.

- Honors any custom scale factor set by the user via ```SDL_RenderSetScale()```. To deal with high-dpi (Retina), apps can set a scale factor on SDL_Renderer when the player has a high-dpi monitor so that, say, (100, 100) is at the same place on screen as non-high-dpi monitors. If the application has done this, and we also apply our own scaling then we get double scaling, so now we don't do any scaling of our own if the user has applied a scale factor to their SDL_Renderer.

- Has a fix so that ```ImGui::Image()``` works with any supplied ```SDL_Texture```